### PR TITLE
Fixed some compilation errors and unit test failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_executable(vl_test
         ${PROJECT_SOURCE_DIR}/visualdl/utils/concurrency.h
         ${PROJECT_SOURCE_DIR}/visualdl/utils/filesystem.h
         )
-target_link_libraries(vl_test sdk storage entry tablet im gtest glog protobuf gflags pthread)
+target_link_libraries(vl_test sdk storage entry tablet im gtest glog protobuf gflags pthread eigen3)
 
 enable_testing ()
 

--- a/visualdl/logic/im.cc
+++ b/visualdl/logic/im.cc
@@ -36,6 +36,7 @@ template class SimpleWriteSyncGuard<Entry<float>>;
 template class SimpleWriteSyncGuard<Entry<double>>;
 template class SimpleWriteSyncGuard<Entry<bool>>;
 template class SimpleWriteSyncGuard<Entry<long>>;
+template class SimpleWriteSyncGuard<Entry<long long>>;
 template class SimpleWriteSyncGuard<Entry<std::string>>;
 template class SimpleWriteSyncGuard<Entry<std::vector<byte_t>>>;
 template class SimpleWriteSyncGuard<Entry<int>>;

--- a/visualdl/logic/sdk.cc
+++ b/visualdl/logic/sdk.cc
@@ -10,7 +10,7 @@ template <typename T>
 std::vector<T> ScalarReader<T>::records() const {
   std::vector<T> res;
   for (int i = 0; i < reader_.total_records(); i++) {
-    res.push_back(reader_.record(i).data<T>(0).Get());
+    res.push_back(reader_.record(i).template data<T>(0).Get());
   }
   return res;
 }

--- a/visualdl/logic/sdk.h
+++ b/visualdl/logic/sdk.h
@@ -122,7 +122,7 @@ struct Scalar {
   void AddRecord(int id, T value) {
     auto record = tablet_.AddRecord();
     record.SetId(id);
-    auto entry = record.AddData<T>();
+    auto entry = record.template AddData<T>();
     entry.Set(value);
   }
 

--- a/visualdl/logic/sdk_test.cc
+++ b/visualdl/logic/sdk_test.cc
@@ -32,7 +32,7 @@ TEST(Scalar, write) {
   ASSERT_EQ(record.front(), 12);
 
   // check tags
-  ASSERT_EQ(reader.all_tags().size(), 1);
+  ASSERT_EQ(reader_.all_tags().size(), 1);
   auto tags = reader.tags("scalar");
   ASSERT_EQ(tags.size(), 2);
   ASSERT_EQ(tags.front(), "scalar0");


### PR DESCRIPTION
* link in eigen3 library to vl_test target
* Add new "template class SimpleWriteSyncGuard<Entry<long long>>;", since build will fail on OSX
* Add template keyboard to data<T>(0).Get() (otherwise this fails on OSX)
* Fix unit test in sdk_test.cc

Tested build and unit test run on OSX and Ubuntu with no issues