### PR TITLE
Move the LogStreamFatal error throw to the destructor.

### DIFF
--- a/visualdl/utils/logging.h
+++ b/visualdl/utils/logging.h
@@ -64,24 +64,22 @@ struct Error : public std::runtime_error {
   explicit Error(const std::string& s) : std::runtime_error(s) {}
 };
 
-// With exception.
+// With exception. The throw occurs in the destructor.
+// Please follow the pattern: LogStreamFatal(__FILE__, __LINE__).stream()
+// so the destructor will immediately execute.
 struct LogStreamFatal {
   LogStreamFatal(const char* file, int line) {
     ss << "[" << file << ":" << line << "] ";
-    throw Error(ss.str());
   }
 
   std::stringstream& stream() { return ss; }
 
   ~LogStreamFatal() {
-    if (!has_throw_) {
-      std::cerr << "throw exception" << std::endl;
-      throw Error(ss.str());
-    }
+    std::cerr << "throw exception" << std::endl;
+    throw Error(ss.str());
   }
 
 private:
-  bool has_throw_{false};
   mutable std::stringstream ss;
 };
 


### PR DESCRIPTION
resolve #205 
https://github.com/PaddlePaddle/VisualDL/issues/205

Since we don't retain the log object, the object will get destroyed immediately. We can safely move the error throw to the destructor. Please let me know if I missed some edge cases. 