### PR TITLE
Add ability to run dev frontend server and connect to a dev backend server.  Currently dev front end server will only serve mock data.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,6 +66,7 @@
     "style-loader": "^0.16.1",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
+    "sync-request": "^5.0.0",
     "url-loader": "^0.5.8",
     "webpack": "^2.4.1",
     "webpack-dev-middleware": "^1.12.1",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ VERSION_NUMBER = read('VERSION_NUMBER')
 LICENSE = readlines('LICENSE')[0].strip()
 
 # use memcache to reduce disk read frequency.
-install_requires = ['Flask', 'numpy', 'Pillow', 'protobuf', 'scipy']
+install_requires = [
+    'Flask', 'numpy', 'Pillow', 'protobuf', 'scipy', 'Flask-Cors'
+]
 execute_requires = ['npm', 'node', 'bash', 'cmake', 'unzip']
 
 

--- a/visualdl/server/visualDL
+++ b/visualdl/server/visualDL
@@ -9,6 +9,7 @@ from argparse import ArgumentParser
 
 from flask import (Flask, Response, redirect, request, send_file,
                    send_from_directory)
+from flask_cors import CORS
 
 import visualdl
 import visualdl.server
@@ -23,6 +24,7 @@ from visualdl.python.storage import (LogWriter, LogReader)
 app = Flask(__name__, static_url_path="")
 # set static expires in a short time to reduce browser's memory usage.
 app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 30
+CORS(app)
 
 error_retry_times = 3
 error_sleep_time = 2  # seconds


### PR DESCRIPTION
1) Start backend server "visualDL --logdir=<log_dir>"
2) Start front-end server, and pass in backend url: "npm run dev -- --backend=http://localhost:8040"