### PR TITLE
VDL slow when user sets incorrect log directory

### DIFF
--- a/visualdl/server/visualDL
+++ b/visualdl/server/visualDL
@@ -235,4 +235,4 @@ if __name__ == '__main__':
             os.mkdir(image_dir)
         graph_image_path = vdl_graph.draw_graph(args.model_pb, image_dir)
 
-    app.run(debug=False, host=args.host, port=args.port)
+    app.run(debug=False, host=args.host, port=args.port, threaded=True)


### PR DESCRIPTION
This fix resolves https://github.com/PaddlePaddle/VisualDL/issues/243

VDL is set to retry an pybinded API call multiple times in case the call fails the first time.  The issue is the method lib.retry will sleep the thread for 2 seconds after an exception.  Since VDL was not running in threaded mode, this causes all request to the server to stop immediately, therefore even requests to get static resource are frozen.  This change enables threaded mode in flask.