### PR TITLE
Initialize the struct static variable right away.

### DIFF
--- a/visualdl/storage/binary_record.cc
+++ b/visualdl/storage/binary_record.cc
@@ -13,9 +13,3 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "visualdl/storage/binary_record.h"
-
-namespace visualdl {
-
-int BinaryRecord::counter_ = 0;
-
-}  // namespace visualdl

--- a/visualdl/storage/binary_record.h
+++ b/visualdl/storage/binary_record.h
@@ -67,6 +67,9 @@ private:
   static int counter_;
 };
 
+// Initial static counter variable.
+int BinaryRecord::counter_ = 0;
+
 struct BinaryRecordReader {
   std::string data;
 


### PR DESCRIPTION
Initialize the static variable right away to avoid getting undefine variable error. 