### PR TITLE
Only write the modified tablets to file system.

### DIFF
--- a/visualdl/storage/storage.cc
+++ b/visualdl/storage/storage.cc
@@ -21,7 +21,7 @@ Storage::Storage() {
   data_ = std::make_shared<storage::Storage>();
   tablets_ = std::make_shared<std::map<std::string, storage::Tablet>>();
   modes_ = std::make_shared<std::set<std::string>>();
-  modified_tablet_set_ = std::set<std::string>();
+  modified_tablet_set_ = std::unordered_set<std::string>();
   time_t t;
   time(&t);
   data_->set_timestamp(t);
@@ -30,6 +30,10 @@ Storage::Storage() {
 Storage::Storage(const Storage& other)
     : data_(other.data_), tablets_(other.tablets_), modes_(other.modes_) {
   dir_ = other.dir_;
+}
+
+Storage::~Storage() {
+    PersistToDisk();
 }
 
 void Storage::AddMode(const std::string& x) {

--- a/visualdl/storage/storage.cc
+++ b/visualdl/storage/storage.cc
@@ -21,6 +21,7 @@ Storage::Storage() {
   data_ = std::make_shared<storage::Storage>();
   tablets_ = std::make_shared<std::map<std::string, storage::Tablet>>();
   modes_ = std::make_shared<std::set<std::string>>();
+  modified_tablet_set_ = std::set<std::string>();
   time_t t;
   time(&t);
   data_->set_timestamp(t);
@@ -43,9 +44,18 @@ Tablet Storage::AddTablet(const std::string& x) {
   CHECK(tablets_->count(x) == 0) << "tablet [" << x << "] has existed";
   (*tablets_)[x] = storage::Tablet();
   AddTag(x);
+  MarkTabletModified(x);
   // WRITE_GUARD
   PersistToDisk();
   return Tablet(&(*tablets_)[x], this);
+}
+
+void Storage::SetDir(const std::string& dir) {
+    *dir_ = dir;
+}
+
+std::string Storage::dir() const {
+    return *dir_;
 }
 
 void Storage::PersistToDisk() { PersistToDisk(*dir_); }
@@ -56,12 +66,29 @@ void Storage::PersistToDisk(const std::string& dir) {
 
   fs::SerializeToFile(*data_, meta_path(dir));
   for (auto tag : data_->tags()) {
-    auto it = tablets_->find(tag);
-    CHECK(it != tablets_->end()) << "tag " << tag << " not exist.";
-    fs::SerializeToFile(it->second, tablet_path(dir, tag));
+    if (modified_tablet_set_.count(tag) > 0){
+        auto it = tablets_->find(tag);
+        CHECK(it != tablets_->end()) << "tag " << tag << " not exist.";
+        fs::SerializeToFile(it->second, tablet_path(dir, tag));
+    }
   }
+  modified_tablet_set_.clear();
 }
 
+Storage* Storage::parent() {
+    return this;
+}
+
+void Storage::MarkTabletModified(const std::string tag) {
+    modified_tablet_set_.insert(tag);
+}
+
+void Storage::AddTag(const std::string& x) {
+    *data_->add_tags() = x;
+    WRITE_GUARD
+  }
+
+// StorageReader
 std::vector<std::string> StorageReader::all_tags() {
   storage::Storage storage;
   Reload(storage);

--- a/visualdl/storage/storage.h
+++ b/visualdl/storage/storage.h
@@ -67,8 +67,8 @@ struct Storage {
   Tablet AddTablet(const std::string& x);
 
   // Set storage's directory.
-  void SetDir(const std::string& dir) { *dir_ = dir; }
-  std::string dir() const { return *dir_; }
+  void SetDir(const std::string& dir);
+  std::string dir() const;
 
   // Save content in memory to `dir_`.
   void PersistToDisk();
@@ -77,20 +77,20 @@ struct Storage {
   void PersistToDisk(const std::string& dir);
 
   // A trick help to retrieve the storage's `SimpleSyncMeta`.
-  Storage* parent() { return this; }
+  Storage* parent();
+
+  void MarkTabletModified(const std::string tag);
 
 protected:
   // Add a tag which content is `x`.
-  void AddTag(const std::string& x) {
-    *data_->add_tags() = x;
-    WRITE_GUARD
-  }
+  void AddTag(const std::string& x);
 
 private:
   std::shared_ptr<std::string> dir_;
   std::shared_ptr<std::map<std::string, storage::Tablet>> tablets_;
   std::shared_ptr<storage::Storage> data_;
   std::shared_ptr<std::set<std::string>> modes_;
+  std::set<std::string> modified_tablet_set_;
 };
 
 // Storage reader, each method will trigger a reading from disk.

--- a/visualdl/storage/storage.h
+++ b/visualdl/storage/storage.h
@@ -58,7 +58,7 @@ struct Storage {
 
   Storage();
   Storage(const Storage& other);
-
+  ~Storage();
   // Add a mode. Mode is similar to TB's FileWriter, It can be "train" or "test"
   // or something else.
   void AddMode(const std::string& x);
@@ -90,7 +90,7 @@ private:
   std::shared_ptr<std::map<std::string, storage::Tablet>> tablets_;
   std::shared_ptr<storage::Storage> data_;
   std::shared_ptr<std::set<std::string>> modes_;
-  std::set<std::string> modified_tablet_set_;
+  std::unordered_set<std::string> modified_tablet_set_;
 };
 
 // Storage reader, each method will trigger a reading from disk.

--- a/visualdl/storage/tablet.cc
+++ b/visualdl/storage/tablet.cc
@@ -13,8 +13,24 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "visualdl/storage/tablet.h"
+#include "visualdl/storage/storage.h"
 
 namespace visualdl {
+
+void Tablet::SetTag(const std::string& mode, const std::string& tag) {
+    auto internal_tag = mode + "/" + tag;
+    string::TagEncode(internal_tag);
+    internal_encoded_tag_ = internal_tag;
+    data_->set_tag(internal_tag);
+    WRITE_GUARD
+}
+
+Record Tablet::AddRecord() {
+    parent()->MarkTabletModified(internal_encoded_tag_);
+    IncTotalRecords();
+    WRITE_GUARD
+    return Record(data_->add_records(), parent());
+}
 
 TabletReader Tablet::reader() { return TabletReader(*data_); }
 

--- a/visualdl/storage/tablet.h
+++ b/visualdl/storage/tablet.h
@@ -29,7 +29,7 @@ struct TabletReader;
  * Tablet is a helper for operations on storage::Tablet.
  */
 struct Tablet {
-  enum Type { kScalar = 0, kHistogram = 1, kImage = 2, kUnknown = 100};
+  enum Type { kScalar = 0, kHistogram = 1, kImage = 2, kUnknown = -1};
 
   DECL_GUARD(Tablet);
 


### PR DESCRIPTION
Move some functions definitions from headers to cc files.

The approach is to track what `tag` is modified in the storage during training. Only process the modified tablets at the PersistToDisk. 

This should cover the first step in https://github.com/PaddlePaddle/VisualDL/issues/284. 
We should also look into if we can only call persistToDisk once at the end of training. Protobuf always serialize all data to the filesystem and that's a huge waste. 