### PR TITLE
Increase the debounce delay so it can pick up the smooth change.

### DIFF
--- a/frontend/src/scalars/ui/Config.vue
+++ b/frontend/src/scalars/ui/Config.vue
@@ -112,7 +112,7 @@ export default {
     smoothingValue: _.debounce(
       function() {
         this.config.smoothing = this.smoothingValue;
-      }, 50
+      }, 500
     ),
   },
   methods: {


### PR DESCRIPTION
This will add some delay to the debouce setting and thus make chart able to pick up the chart setting. 