### PR TITLE
Remove un-necessary debouce import. 

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -19,6 +19,5 @@ module.exports = {
     // so we can have pre-commit running
     'no-invalid-this': 'off',
     'require-jsdoc': 'off',
-    'no-unused-vars': 'off',
   }
 }

--- a/frontend/src/audio/Audio.vue
+++ b/frontend/src/audio/Audio.vue
@@ -31,7 +31,7 @@
 <script>
 
 import {getPluginAudioTags, getRuns} from '../service';
-import {debounce, flatten, uniq} from 'lodash';
+import {flatten, uniq} from 'lodash';
 import autoAdjustHeight from '../common/util/autoAdjustHeight';
 
 import Config from './ui/Config';

--- a/frontend/src/common/util/http.js
+++ b/frontend/src/common/util/http.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
 import qs from 'qs';
-import Notification from '../component/Notification';
+// import Notification from '../component/Notification';
 
-const STATUS = 'status';
-const STATUSINFO = 'msg';
+// const STATUS = 'status';
+// const STATUSINFO = 'msg';
 
 const instance = axios.create({
   baseURL: '/',

--- a/frontend/src/histogram/Histogram.vue
+++ b/frontend/src/histogram/Histogram.vue
@@ -31,7 +31,7 @@
 import {getPluginHistogramsTags, getRuns} from '../service';
 import Config from './ui/Config';
 import ChartPage from './ui/ChartPage';
-import {debounce, flatten, uniq} from 'lodash';
+import {flatten, uniq} from 'lodash';
 import autoAdjustHeight from '../common/util/autoAdjustHeight';
 
 export default {

--- a/frontend/src/images/Images.vue
+++ b/frontend/src/images/Images.vue
@@ -31,7 +31,7 @@
 <script>
 
 import {getPluginImagesTags, getRuns} from '../service';
-import {debounce, flatten, uniq} from 'lodash';
+import {flatten, uniq} from 'lodash';
 import autoAdjustHeight from '../common/util/autoAdjustHeight';
 
 import Config from './ui/Config';

--- a/frontend/src/scalars/Scalars.vue
+++ b/frontend/src/scalars/Scalars.vue
@@ -30,7 +30,7 @@
 
 <script>
 import {getPluginScalarsTags, getRuns} from '../service';
-import {debounce, flatten, uniq} from 'lodash';
+import {flatten, uniq} from 'lodash';
 import autoAdjustHeight from '../common/util/autoAdjustHeight';
 
 import Config from './ui/Config';

--- a/frontend/src/texts/Texts.vue
+++ b/frontend/src/texts/Texts.vue
@@ -31,7 +31,7 @@
 <script>
 
 import {getPluginTextsTags, getRuns} from '../service';
-import {debounce, flatten, uniq} from 'lodash';
+import {flatten, uniq} from 'lodash';
 import autoAdjustHeight from '../common/util/autoAdjustHeight';
 
 import Config from './ui/Config';


### PR DESCRIPTION
Vue comes with the debouce feature. That's why I encountered the variable not used error. Removing those import and bring back the 'no-unused-vars' check.