### PR TITLE
Update the link to the eigen

### DIFF
--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -7,7 +7,7 @@ INCLUDE_DIRECTORIES(${EIGEN_SOURCE_DIR}/src/extern_eigen3)
 ExternalProject_Add(
     extern_eigen3
     ${EXTERNAL_PROJECT_LOG_ARGS}
-    GIT_REPOSITORY  "https://github.com/RLovelett/eigen.git"
+    GIT_REPOSITORY  "https://github.com/libigl/eigen.git"
     GIT_TAG         "master"
     PREFIX          ${EIGEN_SOURCE_DIR}
     UPDATE_COMMAND  ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.14.0
 recommonmark==0.4.0
 scipy==1.0.0
-Sphinx==1.6.6
+Sphinx==1.5.6
 sphinx-rtd-theme==0.2.4
 flake8==3.5.0
 Pillow==5.0.0


### PR DESCRIPTION
The build on Travis CI are failing. This is due to one of our external git link no longer works. Update the link to use its official mirror. 

Also downgrade the Sphinx to use 1.5.6 so it can work well with recommonmark 0.4.0 