### PR TITLE
Windows: link against python

### DIFF
--- a/visualdl/logic/CMakeLists.txt
+++ b/visualdl/logic/CMakeLists.txt
@@ -42,6 +42,9 @@ if (APPLE)
 endif()
 
 if (MSVC)
+  ## On Windows, we still link againt python library
+  target_link_libraries(core PRIVATE python)
+  ## Name the libraries as *.pyd
   set_target_properties(core PROPERTIES PREFIX "" SUFFIX ".pyd")
   add_custom_command(TARGET core POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -E copy


### PR DESCRIPTION
In https://github.com/PaddlePaddle/VisualDL/pull/466 , VisualDL isn't linked against the python library, and this break the Windows build.

This PR adds back the linking on Windows, and will not affect Linux/macOS.

The wheel is build on AppVeyor and the Keras and ONNX demo work correctly.

| Python                   | All                                      |
| ------------------------ | ---------------------------------------- |
| Python 3.6     | [![Build status](https://ci.appveyor.com/api/projects/status/kbvs3etqki06duj1?svg=true)](https://ci.appveyor.com/project/oraoto/visualdl-windows-build) |


