### PR TITLE
Replace expand panel with tabs bar

### DIFF
--- a/frontend/src/common/component/TagsTab.vue
+++ b/frontend/src/common/component/TagsTab.vue
@@ -1,10 +1,13 @@
 <template>
-  <div
-    @click="$emit('click')"
+  <v-card
+    hover
+    color="tag_background"
     class="visual-dl-tags-tab">
+    <div
+      @click="$emit('click')">
     <span :class="active ? 'visual-dl-tags-tab-text-active':'visual-dl-tags-tab-text-inactive' ">{{ title }} &nbsp; ({{ total }})</span>
-    </h3>
-  </div>
+    </div>
+  </v-card>
 </template>
 <script>
 export default {
@@ -26,20 +29,21 @@ export default {
 </script>
 <style lang="stylus">
     .visual-dl-tags-tab
-      border solid 1px #ccc
-      line-height 40px
-      height 40px
+      border-radius 17px
+      line-height 34px
+      height 34px
       padding 0 14px
-      margin-right 20px
+      margin-right 16px
       cursor pointer
       position relative
       display inline-block
       .visual-dl-tags-tab-text-active
-        font-size 13px
+        font-size 12px
         font-weight bold
       .visual-dl-tags-tab-text-inactive
-        font-size 13px
+        font-size 12px
         font-weight normal
+        color #555555
 
 </style>
 

--- a/frontend/src/common/component/TagsTab.vue
+++ b/frontend/src/common/component/TagsTab.vue
@@ -1,0 +1,46 @@
+<template>
+  <div
+    @click="$emit('click')"
+    class="visual-dl-tags-tab">
+    <span :class="active ? 'visual-dl-tags-tab-text-active':'visual-dl-tags-tab-text-inactive' ">{{ title }} &nbsp; ({{ total }})</span>
+    </h3>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    total: {
+      type: Number,
+      required: true,
+    },
+    active: {
+      type: Boolean,
+      required: true,
+    },
+  },
+};
+</script>
+<style lang="stylus">
+    .visual-dl-tags-tab
+      border solid 1px #ccc
+      line-height 40px
+      height 40px
+      padding 0 14px
+      margin-right 20px
+      cursor pointer
+      position relative
+      display inline-block
+      .visual-dl-tags-tab-text-active
+        font-size 13px
+        font-weight bold
+      .visual-dl-tags-tab-text-inactive
+        font-size 13px
+        font-weight normal
+
+</style>
+
+

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -11,7 +11,8 @@ Vue.use(Vuetify, {
     primary: '#008c99',
     accent: '#008c99',
     toolbox_icon: '#999999',
-    dark_primary: '#00727c'
+    dark_primary: '#00727c',
+    tag_background: '#f5f5f5',
   },
 });
 

--- a/frontend/src/metrics/Metrics.vue
+++ b/frontend/src/metrics/Metrics.vue
@@ -1,17 +1,28 @@
 <template>
   <div class="visual-dl-page-container">
     <div class="visual-dl-page-left">
+
+      <div>
+        <ui-tags-tab
+          :total="tagsListCount(allTagsMatchingList)"
+          :title="'Tags matching' + config.groupNameReg"
+          :active="selectedGroup === '' "
+          @click="selectedGroup = '' "
+        />
+        <ui-tags-tab
+          v-for="item in groupedTags"
+          :key="item.group"
+          :total="tagsListCount(item.tags)"
+          :title="item.group"
+          :active="item.group === selectedGroup"
+          @click="selectedGroup = item.group"
+        />
+      </div>
+
       <ui-chart-page
         :config="config"
-        :tag-list="filteredTagsList"
-        :title="'Tags matching' + config.groupNameReg"
-      />
-      <ui-chart-page
-        v-for="item in groupedTags"
-        :key="item.group"
-        :config="config"
-        :tag-list="item.tags"
-        :title="item.group"
+        :tag-list="finalTagsList"
+        :total="tagsListCount(finalTagsList)"
       />
     </div>
 
@@ -27,9 +38,10 @@
 
 <script>
 import {getPluginScalarsTags, getPluginHistogramsTags} from '../service';
-import {flatten, uniq} from 'lodash';
+import {cloneDeep, flatten, uniq} from 'lodash';
 import autoAdjustHeight from '../common/util/autoAdjustHeight';
 
+import TagsTab from '../common/component/TagsTab';
 import Config from './ui/Config';
 import ChartPage from './ui/ChartPage';
 
@@ -37,21 +49,22 @@ export default {
   components: {
     'ui-config': Config,
     'ui-chart-page': ChartPage,
+    'ui-tags-tab': TagsTab,
   },
   props: {
-      runs: {
-        type: Array,
-        required: true,
-      },
+    runs: {
+      type: Array,
+      required: true,
+    },
   },
   data() {
     return {
-      tagInfo: { scalar: {}, histogram: {} },
+      tagInfo: {scalar: {}, histogram: {}},
       config: {
         groupNameReg: '.*',
-        //scalar 'enabled' will be false when no scalar logs available, 'display' is toggled by user in config
-        scalar: { enabled: false, display: false },
-        histogram: { enabled: false, display: false },
+        // scalar 'enabled' will be false when no scalar logs available, 'display' is toggled by user in config
+        scalar: {enabled: false, display: false},
+        histogram: {enabled: false, display: false},
         smoothing: 0.6,
         horizontal: 'step',
         sortingMethod: 'default',
@@ -60,16 +73,34 @@ export default {
         running: true,
         chartType: 'offset',
       },
-      filteredTagsList: { scalar: [], histogram: [] },
+      filteredTagsList: {scalar: [], histogram: []},
+      selectedGroup: '',
     };
   },
   computed: {
+    finalTagsList() {
+      if (this.selectedGroup === '') {
+        return this.allTagsMatchingList;
+      } else {
+        let list;
+        this.groupedTags.forEach((item) => {
+          if (item.group === this.selectedGroup) {
+            list = item.tags;
+          }
+        });
+        return list;
+      }
+    },
+    allTagsMatchingList() {
+      let list = cloneDeep(this.filteredTagsList);
+      list.scalar = this.filteredListByRunsForScalar(list.scalar);
+      list.histogram = this.filteredListByRunsForHistogram(list.histogram);
+      return list;
+    },
     tagsList() {
-
-      var list = {};
+      let list = {};
 
       Object.keys(this.tagInfo).forEach((type) => {
-
         let tags = this.tagInfo[type];
 
         let runs = Object.keys(tags);
@@ -95,7 +126,6 @@ export default {
       return list;
     },
     groupedTags() {
-
       let tagsList = this.tagsList || [];
 
       // put data in group
@@ -105,15 +135,15 @@ export default {
         let tagsForEachType = tagsList[type];
 
         tagsForEachType.forEach((item) => {
-
           let group = item.group;
 
           if (groupData[group] === undefined) {
-            groupData[group] = {}
+            groupData[group] = {};
           }
           if (groupData[group][type] === undefined) {
             groupData[group][type] = [];
           }
+
           groupData[group][type].push(item);
         });
       });
@@ -121,6 +151,9 @@ export default {
       // to array
       let groups = Object.keys(groupData);
       let groupList = groups.map((group) => {
+        groupData[group].scalar = this.filteredListByRunsForScalar(groupData[group].scalar);
+        groupData[group].histogram = this.filteredListByRunsForHistogram(groupData[group].histogram);
+
         return {
           group,
           tags: groupData[group],
@@ -158,9 +191,9 @@ export default {
     'config.groupNameReg': function(val) {
       this.throttledFilterTagsList();
     },
-    runs: function(val) {
+    'runs': function(val) {
       this.config.runs = val;
-    }
+    },
   },
   methods: {
     filterTagsList(groupNameReg) {
@@ -183,6 +216,30 @@ export default {
         this.filterTagsList(this.config.groupNameReg);
       }, 300
     ),
+    filteredListByRunsForScalar(scalar) {
+      if (!this.config.scalar.display) return [];
+      let runs = this.config.runs || [];
+      let list = cloneDeep(scalar) || [];
+      list = list.map((item) => {
+        item.tagList = item.tagList.filter((one) => runs.includes(one.run));
+        return item;
+      });
+      return list.filter((item) => item.tagList.length > 0);
+    },
+    filteredListByRunsForHistogram(histogram) {
+      if (!this.config.histogram.display) return [];
+      let runs = this.config.runs || [];
+      let list = cloneDeep(histogram) || [];
+      return flatten(list.map((item) => {
+        return item.tagList.filter((one) => runs.includes(one.run));
+      }));
+    },
+    tagsListCount(tagsList) {
+      let count = 0;
+      if (tagsList.scalar !== undefined) count += tagsList.scalar.length;
+      if (tagsList.histogram !== undefined) count += tagsList.histogram.length;
+      return count;
+    },
   },
 };
 

--- a/frontend/src/metrics/Metrics.vue
+++ b/frontend/src/metrics/Metrics.vue
@@ -11,7 +11,6 @@
         />
         <ui-tags-tab
           v-for="item in groupedTags"
-          :key="item.group"
           :total="tagsListCount(item.tags)"
           :title="item.group"
           :active="item.group === selectedGroup"

--- a/frontend/src/metrics/Metrics.vue
+++ b/frontend/src/metrics/Metrics.vue
@@ -49,6 +49,9 @@ export default {
       tagInfo: { scalar: {}, histogram: {} },
       config: {
         groupNameReg: '.*',
+        //scalar 'enabled' will be false when no scalar logs available, 'display' is toggled by user in config
+        scalar: { enabled: false, display: false },
+        histogram: { enabled: false, display: false },
         smoothing: 0.6,
         horizontal: 'step',
         sortingMethod: 'default',
@@ -129,12 +132,20 @@ export default {
   },
   created() {
     getPluginScalarsTags().then(({errno, data}) => {
+      if (!data) return;
+
       this.tagInfo.scalar = data;
+      this.config.scalar.enabled = true;
+      this.config.scalar.display = true;
       this.filterTagsList(this.config.groupNameReg);
     });
 
     getPluginHistogramsTags().then(({errno, data}) => {
+      if (!data) return;
+
       this.tagInfo.histogram = data;
+      this.config.histogram.enabled = true;
+      this.config.histogram.display = true;
       this.filterTagsList(this.config.groupNameReg);
     });
 

--- a/frontend/src/metrics/ui/ChartPage.vue
+++ b/frontend/src/metrics/ui/ChartPage.vue
@@ -32,7 +32,6 @@
   </div>
 </template>
 <script>
-import ExpandPanel from '../../common/component/ExpandPanel';
 import ScalarChart from './ScalarChart';
 import HistogramChart from './HistogramChart';
 
@@ -40,7 +39,6 @@ export default {
   components: {
     'ui-scalar-chart': ScalarChart,
     'ui-histogram-chart': HistogramChart,
-    'ui-expand-panel': ExpandPanel,
   },
   props: {
     config: {
@@ -61,7 +59,7 @@ export default {
       // current page
       currentPage: 1,
       // item per page
-      pageSize: 4,
+      pageSize: 12,
     };
   },
   computed: {
@@ -84,7 +82,7 @@ export default {
     'config.runs': function(val) {
       this.currentPage = 1;
     },
-    'tagList': function(val) {
+    tagList: function(val) {
       this.currentPage = 1;
     },
   },

--- a/frontend/src/metrics/ui/ChartPage.vue
+++ b/frontend/src/metrics/ui/ChartPage.vue
@@ -1,45 +1,40 @@
 <template>
   <div class="visual-dl-chart-page">
-    <ui-expand-panel
-      :info="total"
-      :title="title">
-      <div
-        ref="chartPageBox"
-        class="visual-dl-chart-page-box">
+    <div
+      ref="chartPageBox"
+      class="visual-dl-chart-page-box">
 
-        <ui-scalar-chart
-          v-for="(tagInfo, index) in filteredScalarTagList"
-          :tag-info="tagInfo"
-          :smoothing="config.smoothing"
-          :horizontal="config.horizontal"
-          :sorting-method="config.sortingMethod"
-          :outlier="config.outlier"
-          :runs="config.runs"
-          :running="config.running"
-        />
-
-        <ui-histogram-chart
-          v-for="(tagInfo, index) in filteredHistogramTagList"
-          :tag-info="tagInfo"
-          :runs="config.runs"
-          :chart-type="config.chartType"
-          :running="config.running"
-        />
-
-      </div>
-      <v-pagination
-        v-if="total > pageSize"
-        v-model="currentPage"
-        :length="pageLength"
+      <ui-scalar-chart
+        v-for="(tagInfo, index) in filteredScalarTagList"
+        :tag-info="tagInfo"
+        :smoothing="config.smoothing"
+        :horizontal="config.horizontal"
+        :sorting-method="config.sortingMethod"
+        :outlier="config.outlier"
+        :runs="config.runs"
+        :running="config.running"
       />
-    </ui-expand-panel>
+
+      <ui-histogram-chart
+        v-for="(tagInfo, index) in filteredHistogramTagList"
+        :tag-info="tagInfo"
+        :runs="config.runs"
+        :chart-type="config.chartType"
+        :running="config.running"
+      />
+
+    </div>
+    <v-pagination
+      v-if="total > pageSize"
+      v-model="currentPage"
+      :length="pageLength"
+    />
   </div>
 </template>
 <script>
 import ExpandPanel from '../../common/component/ExpandPanel';
 import ScalarChart from './ScalarChart';
 import HistogramChart from './HistogramChart';
-import {cloneDeep, flatten} from 'lodash';
 
 export default {
   components: {
@@ -56,8 +51,8 @@ export default {
       type: Object,
       required: true,
     },
-    title: {
-      type: String,
+    total: {
+      type: Number,
       required: true,
     },
   },
@@ -66,43 +61,20 @@ export default {
       // current page
       currentPage: 1,
       // item per page
-      pageSize: 12,
+      pageSize: 4,
     };
   },
   computed: {
-    filteredListByRunsForScalar() {
-      if (!this.config.scalar.display) return [];
-      let runs = this.config.runs || [];
-      let list = cloneDeep(this.tagList.scalar) || [];
-      list = list.slice().map((item) => {
-        item.tagList = item.tagList.filter((one) => runs.includes(one.run));
-        return item;
-      });
-      return list.filter((item) => item.tagList.length > 0);
-    },
-    filteredListByRunsForHistogram() {
-      if (!this.config.histogram.display) return [];
-      let runs = this.config.runs || [];
-      let list = cloneDeep(this.tagList.histogram) || [];
-      return flatten(list.slice().map((item) => {
-        return item.tagList.filter((one) => runs.includes(one.run));
-      }));
-    },
     filteredScalarTagList() {
-        return this.filteredListByRunsForScalar.slice((this.currentPage - 1) * this.pageSize, this.currentPage * this.pageSize);
+      return this.tagList.scalar.slice((this.currentPage - 1) * this.pageSize, this.currentPage * this.pageSize);
     },
     filteredHistogramTagList() {
-        let offset = this.filteredListByRunsForScalar.length;
-        let start = (this.currentPage - 1) * this.pageSize - offset;
-        if (start < 0) start = 0;
-        let end = this.currentPage * this.pageSize - offset;
-        if (end < 0) end = 0;
-        return this.filteredListByRunsForHistogram.slice(start, end);
-    },
-    total() {
-      let scalarList = this.filteredListByRunsForScalar || [];
-      let histogramList = this.filteredListByRunsForHistogram || [];
-      return scalarList.length + histogramList.length;
+      let offset = this.tagList.scalar.length;
+      let start = (this.currentPage - 1) * this.pageSize - offset;
+      if (start < 0) start = 0;
+      let end = this.currentPage * this.pageSize - offset;
+      if (end < 0) end = 0;
+      return this.tagList.histogram.slice(start, end);
     },
     pageLength() {
       return Math.ceil(this.total / this.pageSize);
@@ -111,8 +83,11 @@ export default {
   watch: {
     'config.runs': function(val) {
       this.currentPage = 1;
-    }
-  }
+    },
+    'tagList': function(val) {
+      this.currentPage = 1;
+    },
+  },
 };
 </script>
 <style lang="stylus">

--- a/frontend/src/metrics/ui/ChartPage.vue
+++ b/frontend/src/metrics/ui/ChartPage.vue
@@ -71,6 +71,7 @@ export default {
   },
   computed: {
     filteredListByRunsForScalar() {
+      if (!this.config.scalar.display) return [];
       let runs = this.config.runs || [];
       let list = cloneDeep(this.tagList.scalar) || [];
       list = list.slice().map((item) => {
@@ -80,6 +81,7 @@ export default {
       return list.filter((item) => item.tagList.length > 0);
     },
     filteredListByRunsForHistogram() {
+      if (!this.config.histogram.display) return [];
       let runs = this.config.runs || [];
       let list = cloneDeep(this.tagList.histogram) || [];
       return flatten(list.slice().map((item) => {
@@ -87,7 +89,6 @@ export default {
       }));
     },
     filteredScalarTagList() {
-        console.log("filteredScalarTagList");
         return this.filteredListByRunsForScalar.slice((this.currentPage - 1) * this.pageSize, this.currentPage * this.pageSize);
     },
     filteredHistogramTagList() {

--- a/frontend/src/metrics/ui/Config.vue
+++ b/frontend/src/metrics/ui/Config.vue
@@ -7,47 +7,81 @@
       dark
     />
 
-    <div class="visual-dl-page-slider-block">
-      <v-slider
-        label="Smoothing"
-        :max="0.99"
-        :min="0"
-        :step="0.01"
-        v-model="smoothingValue"
-        class="visual-dl-page-smoothing-slider"
-        dark/>
-      <span class="visual-dl-page-slider-span">{{ smoothingValue }}</span>
+    <v-checkbox
+      class="visual-dl-page-config-checkbox"
+      label="Scalars"
+      v-model="config.scalar.display"
+      :disabled="!config.scalar.enabled"
+      dark/>
+
+    <div class="visual-dl-page-component-block">
+
+        <div class="visual-dl-page-control-block">
+          <span :class="'visual-dl-page-control-span' + (config.scalar.display ? '' : ' visual-dl-page-disabled-text')">Smoothing</span>
+          <v-slider
+            :max="0.99"
+            :min="0"
+            :step="0.01"
+            v-model="smoothingValue"
+            class="visual-dl-page-smoothing-slider"
+            dark
+            :disabled="!config.scalar.display"/>
+          <span :class="'visual-dl-page-slider-span' + (config.scalar.display ? '' : ' visual-dl-page-disabled-text')">{{ smoothingValue }}</span>
+        </div>
+
+        <div class="visual-dl-page-control-block">
+            <span :class="'visual-dl-page-control-span' + (config.scalar.display ? '' : ' visual-dl-page-disabled-text')">X-axis</span>
+            <v-select
+              :items="horizontalItems"
+              v-model="config.horizontal"
+              class="visual-dl-page-config-selector"
+              dark
+              dense
+              :disabled="!config.scalar.display"
+            />
+        </div>
+
+        <div class="visual-dl-page-control-block">
+            <span :class="'visual-dl-page-control-span' + (config.scalar.display ? '' : ' visual-dl-page-disabled-text')">Tooltip sorting</span>
+            <v-select
+              :items="sortingMethodItems"
+              v-model="config.sortingMethod"
+              class="visual-dl-page-config-selector"
+              dark
+              dense
+              :disabled="!config.scalar.display"
+            />
+        </div>
+
+        <v-checkbox
+          class="visual-dl-page-outliers-checkbox"
+          label="Ignore outliers in chart scaling"
+          v-model="config.outlier"
+          dark
+          :disabled="!config.scalar.display"/>
+
     </div>
-
-    <v-radio-group
-      label="X-Axis"
-      v-model="config.horizontal"
-      dark>
-      <v-radio
-        label="Step"
-        value="step"/>
-      <v-radio
-        label="Relative"
-        value="relative"/>
-      <v-radio
-        label="Wall Time"
-        value="wall"/>
-    </v-radio-group>
-
-    <v-select
-      :items="sortingMethodItems"
-      v-model="config.sortingMethod"
-      label="Tooltip sorting method"
-      class="visual-dl-page-config-selector"
-      dark
-      dense
-    />
 
     <v-checkbox
       class="visual-dl-page-config-checkbox"
-      label="Ignore outliers in chart scaling"
-      v-model="config.outlier"
+      label="Histogram"
+      v-model="config.histogram.display"
+      :disabled="!config.histogram.enabled"
       dark/>
+
+      <div class="visual-dl-page-component-block">
+         <div class="visual-dl-page-control-block">
+           <span :class="'visual-dl-page-control-span' + (config.histogram.display ? '' : ' visual-dl-page-disabled-text')">Mode</span>
+           <v-select
+              :items="chartTypeItems"
+              v-model="config.chartType"
+              class="visual-dl-page-config-selector"
+              dark
+              dense
+              :disabled="!config.histogram.display"
+            />
+        </div>
+      </div>
 
     <v-btn
       :color="config.running ? 'primary' : 'error'"
@@ -75,20 +109,30 @@ export default {
     return {
       horizontalItems: [
         {
-          name: 'Step',
+          text: 'Step',
           value: 'step',
         },
         {
-          name: 'Relative',
+          text: 'Relative',
           value: 'relative',
         },
         {
-          name: 'Wall',
+          text: 'Wall Time',
           value: 'wall',
         },
       ],
       sortingMethodItems: [
         'default', 'descending', 'ascending', 'nearest',
+      ],
+      chartTypeItems: [
+        {
+          text: 'Overlay',
+          value: 'overlay',
+        },
+        {
+          text: 'Offset',
+          value: 'offset',
+        },
       ],
       smoothingValue: this.config.smoothing,
       isDemo: process.env.NODE_ENV === 'demo',
@@ -98,7 +142,7 @@ export default {
     smoothingValue: _.debounce(
       function() {
         this.config.smoothing = this.smoothingValue;
-      }, 500
+      }, 50
     ),
   },
   methods: {
@@ -113,24 +157,37 @@ export default {
 +prefix-classes('visual-dl-page-')
     .config-com
         padding 20px
-        .slider-block
+        .component-block
+            padding-left 33px
+            padding-bottom 20px
+            margin-top -10px
+        .control-block
+            height 36px
             display flex
             align-items center
+        .control-span
+            font-size 12px
+            width 110px
+            margin-top 8px
+        .disabled-text
+            opacity 0.5
         .smoothing-slider
             display inline
         .slider-span
-            width 40px
+            width 35px
+            font-size 13px
         .run-toggle
             margin-top 20px
         .config-checkbox label
             font-size 13px
-        .config-selector
-            margin-top 12px
-            margin-bottom 20px
-        .checkbox-group-label
-            display flex
-            margin-top 20px
-            margin-bottom 10px
+            font-weight bold
+        .outliers-checkbox
+            margin-top 10px
+        .outliers-checkbox label
+            font-size 12px
+
+.input-group--select .input-group__selections__comma
+    font-size 12px
 
 </style>
 

--- a/frontend/src/metrics/ui/HistogramChart.vue
+++ b/frontend/src/metrics/ui/HistogramChart.vue
@@ -66,6 +66,13 @@ export default {
     };
   },
   watch: {
+    tagInfo: function(val) {
+      this.initChart(val);
+      this.stopInterval();
+      if (this.running && !this.isDemo) {
+        this.startInterval();
+      }
+    },
     originData: function(val) {
       this.initChartOption();
     },

--- a/frontend/src/samples/ui/Audio.vue
+++ b/frontend/src/samples/ui/Audio.vue
@@ -109,6 +109,10 @@ export default {
         };
       }
     },
+    tagInfo: function(val) {
+      this.currentIndex = 0;
+      this.getOriginAudioData();
+    }
   },
   methods: {
     stopInterval() {

--- a/frontend/src/samples/ui/Image.vue
+++ b/frontend/src/samples/ui/Image.vue
@@ -126,6 +126,10 @@ export default {
       }
       /* eslint-enable fecs-camelcase */
     },
+    tagInfo: function(val) {
+      this.currentIndex = 0;
+      this.getOriginChartsData();
+    }
   },
   methods: {
     stopInterval() {

--- a/frontend/src/samples/ui/SamplePage.vue
+++ b/frontend/src/samples/ui/SamplePage.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="visual-dl-chart-page">
-    <ui-expand-panel
-      :info="total"
-      :title="title">
 
       <div class="visual-dl-sample-chart-box">
         <ui-image
@@ -39,23 +36,18 @@
         v-model="currentPage"
         :length="pageLength"
       />
-    </ui-expand-panel>
   </div>
 </template>
 <script>
-import ExpandPanel from '../../common/component/ExpandPanel';
 import Image from './Image';
 import Audio from './Audio';
 import Text from './Text';
-
-import {cloneDeep, flatten} from 'lodash';
 
 export default {
   components: {
     'ui-image': Image,
     'ui-audio': Audio,
     'ui-text': Text,
-    'ui-expand-panel': ExpandPanel,
   },
   props: {
     config: {
@@ -66,8 +58,8 @@ export default {
       type: Object,
       required: true,
     },
-    title: {
-      type: String,
+    total: {
+      type: Number,
       required: true,
     },
   },
@@ -80,54 +72,24 @@ export default {
     };
   },
   computed: {
-    filteredListByRunsForImage() {
-      if (!this.config.image.display) return [];
-      let runs = this.config.runs || [];
-      let list = cloneDeep(this.tagList.image) || [];
-      return flatten(list.slice().map((item) => {
-        return item.tagList.filter((one) => runs.includes(one.run));
-      }));
-    },
-    filteredListByRunsForAudio() {
-      if (!this.config.audio.display) return [];
-      let runs = this.config.runs || [];
-      let list = cloneDeep(this.tagList.audio) || [];
-      return flatten(list.slice().map((item) => {
-        return item.tagList.filter((one) => runs.includes(one.run));
-      }));
-    },
-    filteredListByRunsForText() {
-      if (!this.config.text.display) return [];
-      let runs = this.config.runs || [];
-      let list = cloneDeep(this.tagList.text) || [];
-      return flatten(list.slice().map((item) => {
-        return item.tagList.filter((one) => runs.includes(one.run));
-      }));
-    },
     filteredImageTagList() {
-        return this.filteredListByRunsForImage.slice((this.currentPage - 1) * this.pageSize, this.currentPage * this.pageSize);
+        return this.tagList.image.slice((this.currentPage - 1) * this.pageSize, this.currentPage * this.pageSize);
     },
     filteredAudioTagList() {
-        let offset = this.filteredListByRunsForImage.length;
+        let offset = this.tagList.image.length;
         let start = (this.currentPage - 1) * this.pageSize - offset;
         if (start < 0) start = 0;
         let end = this.currentPage * this.pageSize - offset;
         if (end < 0) end = 0;
-        return this.filteredListByRunsForAudio.slice(start, end);
+        return this.tagList.audio.slice(start, end);
     },
     filteredTextTagList() {
-        let offset = this.filteredListByRunsForImage.length + this.filteredListByRunsForAudio.length;
+        let offset = this.tagList.image.length + this.tagList.audio.length;
         let start = (this.currentPage - 1) * this.pageSize - offset;
         if (start < 0) start = 0;
         let end = this.currentPage * this.pageSize - offset;
         if (end < 0) end = 0;
-        return this.filteredListByRunsForText.slice(start, end);
-    },
-    total() {
-      let imageList = this.filteredListByRunsForImage || [];
-      let audioList = this.filteredListByRunsForAudio || [];
-      let textList = this.filteredListByRunsForText || [];
-      return imageList.length + audioList.length + textList.length;
+        return this.tagList.text.slice(start, end);
     },
     pageLength() {
       return Math.ceil(this.total / this.pageSize);
@@ -136,7 +98,10 @@ export default {
   watch: {
     'config.runs': function(val) {
       this.currentPage = 1;
-    }
+    },
+    tagList: function(val) {
+      this.currentPage = 1;
+    },
   },
 };
 </script>

--- a/frontend/src/samples/ui/Text.vue
+++ b/frontend/src/samples/ui/Text.vue
@@ -106,6 +106,10 @@ export default {
         };
       }
     },
+    tagInfo: function(val) {
+      this.currentIndex = 0;
+      this.getOriginChartsData();
+    }
   },
   methods: {
     stopInterval() {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/985199/45518318-ea94cb80-b765-11e8-821e-1339ed76f3ac.png)



Add a bar with different Group tag to select by users

- Users can switch to different group tag by tab instead of using expand panel
- Expand panel is confusing and difficult to see all group tags
- Optimize performance by not showing duplicate instance of chart