### PR TITLE
Use latest protobuf 3.1.x in Windows.

### DIFF
--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -184,7 +184,8 @@ FUNCTION(build_protobuf TARGET_NAME BUILD_FOR_HOST)
             ${EXTERNAL_PROJECT_LOG_ARGS}
             PREFIX          ${PROTOBUF_SOURCES_DIR}
             UPDATE_COMMAND  ""
-            URL https://github.com/google/protobuf/archive/v3.1.0.zip
+            GIT_REPOSITORY  "https://github.com/google/protobuf.git"
+            GIT_TAG         "9f69353562fe1fbb3fbd11345ea3676b0eb267cd"
             CONFIGURE_COMMAND
             ${CMAKE_COMMAND} ${PROTOBUF_SOURCES_DIR}/src/${TARGET_NAME}/cmake
                 ${OPTIONAL_ARGS}


### PR DESCRIPTION
In https://github.com/PaddlePaddle/VisualDL/pull/518 , protobuf was changed to 3.1.0 which break the Windows build.

To build protobuf 3.1 in Windows, an upstream patch https://github.com/protocolbuffers/protobuf/commit/1d2c7b6c7376f396c8c7dd9b6afd2d4f83f3cb05 is required. 

This PR use the latest version of  [protobuf  3.1.x](https://github.com/protocolbuffers/protobuf/tree/3.1.x) which includes the required patch. Python 3.5, 3.7, 3.7 are testd: [AppVeyor](https://ci.appveyor.com/project/oraoto/visualdl-windows-build)
