### PR TITLE
Fix the problem of image normalizaiton

### DIFF
--- a/visualdl/logic/sdk.cc
+++ b/visualdl/logic/sdk.cc
@@ -272,7 +272,7 @@ ImageReader::ImageRecord ImageReader::record(int offset, int index) {
   std::transform(brcd.data.begin(),
                  brcd.data.end(),
                  std::back_inserter(res.data),
-                 [](byte_t i) { return (int)(i); });
+                 [](byte_t i) { return (uint8_t)(i); });
   res.shape = entry.GetMulti<shape_t>();
   res.step_id = record.id();
   return res;

--- a/visualdl/utils/image.h
+++ b/visualdl/utils/image.h
@@ -78,6 +78,7 @@ static void NormalizeImage(Uint8Image* image,
   if (image_min < 0) {
     float max_val = std::max(std::abs(image_min), image_max);
     scale = (max_val < kZeroThreshold ? 0.0f : 127.0f) / max_val;
+    offset = 127.0f;
   } else {
     scale = (image_max < kZeroThreshold ? 0.0f : 255.0f) / image_max;
     offset = 0.0f;


### PR DESCRIPTION
first, offset should be set to 127.0f when image_min < 0, the bug is in visualdl/utils/image.h
second, byte_t can't be transformed to int directly , otherwise the value is unpredictable. I have fix this bug in visualdl/logic/sdk.cc