### PR TITLE
Fix the bug caused by Histogram.

### DIFF
--- a/visualdl/logic/histogram.h
+++ b/visualdl/logic/histogram.h
@@ -46,6 +46,8 @@ struct HistogramRecord {
         frequency(frequency),
         span_(float(right - left) / frequency.size()) {}
 
+  ~HistogramRecord() { frequency.clear(); }
+
   Instance instance(int i) const {
     CHECK_LT(i, frequency.size());
     Instance res;


### PR DESCRIPTION
The Histogram Constructor have allocated memory for storing
the variable vector<int> frequency, but not release after then.
I have created a destructor function to free the memory.