### PR TITLE
解决Logwriter在pycharm中的警告

### DIFF
--- a/visualdl/writer/writer.py
+++ b/visualdl/writer/writer.py
@@ -168,7 +168,7 @@ class LogWriter(object):
 
         Args:
             tag (string): Data identifier
-            img (numpy.ndarray): Image represented by a numpy.array
+            img (np.ndarray): Image represented by a numpy.array
             step (int): Step of image
             walltime (int): Wall time of image
             dataformats (string): Format of image


### PR DESCRIPTION
VisualDL/visualdl/writer/writer.py
LogWriter.add_image函数
注释
Args:
tag (string): Data identifier
img (numpy.ndarray): Image represented by a numpy.array
step (int): Step of image
walltime (int): Wall time of image
dataformats (string): Format of image
第二个参数img的注释需修改为img (np.ndarray)
Args:
tag (string): Data identifier
img (np.ndarray): Image represented by a numpy.array
step (int): Step of image
walltime (int): Wall time of image
dataformats (string): Format of image
因为之前已经进行了import numpy as np
如果此处写numpy.ndarray会在pycharm中报一个警告
“Expected type 'Type[ndarray]', got 'ndarray' instead”