### PR TITLE
fix a bug in get_vdl_log_file when logdir does not exist

### DIFF
--- a/visualdl/server/serve.py
+++ b/visualdl/server/serve.py
@@ -64,6 +64,7 @@ def get_vdl_log_file(logdirs):
                             "exp2": "vdlrecords.1587375685.log"}
     """
     walks = {}
+    walks_temp = {}
     for logdir in logdirs:
         for root, dirs, files in bfile.walk(logdir):
             walks.update({root: files})

--- a/visualdl/server/serve.py
+++ b/visualdl/server/serve.py
@@ -69,13 +69,12 @@ def get_vdl_log_file(logdirs):
         for root, dirs, files in bfile.walk(logdir):
             walks.update({root: files})
 
-            walks_temp = {}
-            for run, tags in walks.items():
-                tags_temp = [tag for tag in tags if
-                             is_VDLRecord_file(path=bfile.join(run, tag), check=False)]
-                tags_temp.sort(reverse=True)
-                if len(tags_temp) > 0:
-                    walks_temp.update({run: tags_temp[0]})
+    for run, tags in walks.items():
+        tags_temp = [tag for tag in tags if
+                        is_VDLRecord_file(path=bfile.join(run, tag), check=False)]
+        tags_temp.sort(reverse=True)
+        if len(tags_temp) > 0:
+            walks_temp.update({run: tags_temp[0]})
 
     return walks_temp
 

--- a/visualdl/server/serve.py
+++ b/visualdl/server/serve.py
@@ -71,7 +71,7 @@ def get_vdl_log_file(logdirs):
 
     for run, tags in walks.items():
         tags_temp = [tag for tag in tags if
-                        is_VDLRecord_file(path=bfile.join(run, tag), check=False)]
+                     is_VDLRecord_file(path=bfile.join(run, tag), check=False)]
         tags_temp.sort(reverse=True)
         if len(tags_temp) > 0:
             walks_temp.update({run: tags_temp[0]})


### PR DESCRIPTION
When logdir does not exist, variable "walks_temp" will not be defined before referenced. Fix this bug by defining this variable.