### PR TITLE
fix a bug for main thread deadlock due to writing thread down

### DIFF
--- a/visualdl/io/bfile.py
+++ b/visualdl/io/bfile.py
@@ -406,6 +406,12 @@ class BosFileSystem(object):
                     content_length=len(init_data))
             except (exception.BceServerError, exception.BceHttpClientError):
                 self.renew_bos_client_from_server()
+                self.bos_client.append_object(
+                    bucket_name=bucket_name,
+                    key=object_key,
+                    data=init_data,
+                    content_md5=content_md5(init_data),
+                    content_length=len(init_data))
                 return
         content_length = len(file_content)
 
@@ -421,13 +427,15 @@ class BosFileSystem(object):
                 offset=offset)
         except (exception.BceServerError, exception.BceHttpClientError):
             self.renew_bos_client_from_server()
-            init_data = b''
+            offset = self.get_meta(bucket_name,
+                                   object_key).metadata.content_length
             self.bos_client.append_object(
                 bucket_name=bucket_name,
                 key=object_key,
-                data=init_data,
-                content_md5=content_md5(init_data),
-                content_length=len(init_data))
+                data=file_content,
+                content_md5=content_md5(file_content),
+                content_length=content_length,
+                offset=offset)
 
         self._file_contents_to_add = b''
         self._file_contents_count = 0

--- a/visualdl/writer/record_writer.py
+++ b/visualdl/writer/record_writer.py
@@ -99,10 +99,10 @@ class RecordFileWriter(object):
             else:
                 fn = "vdlrecords.%010d.log%s" % (time.time(), filename_suffix)
                 self._file_name = bfile.join(logdir, fn)
-                print(
-                    'Since the log filename should contain `vdlrecords`, the filename is invalid and `{}` will replace `{}`'
-                    .format(  # noqa: E501
-                        fn, filename))
+                print('Since the log filename should contain `vdlrecords`, '
+                      'the filename is invalid and `{}` will replace `{}`'.
+                      format(  # noqa: E501
+                          fn, filename))
         else:
             self._file_name = bfile.join(
                 logdir,

--- a/visualdl/writer/record_writer.py
+++ b/visualdl/writer/record_writer.py
@@ -196,6 +196,7 @@ class _AsyncWriterThread(threading.Thread):
         self.join()
 
     def run(self):
+        has_unresolved_bug = False
         while True:
             now = time.time()
             queue_wait_duration = self._next_flush_time - now
@@ -215,7 +216,11 @@ class _AsyncWriterThread(threading.Thread):
                 pass
             except Exception as e:
                 # prevent the main thread from deadlock due to writing error.
-                print('Writing data Error, Due to Exception {}'.format(e))
+                if not has_unresolved_bug:
+                    print('Warning: Writing data Error, Due to unresolved Exception {}'.format(e))
+                    print('Warning: Writing data to FileSystem failed since {}.'.format(
+                        time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime())))
+                has_unresolved_bug = True
                 pass
             finally:
                 if data:


### PR DESCRIPTION
## Bug描述：
  当主线程调用_AsyncWriter类的flush方法时，会对queue进行join等待，子线程会从queue中取出内容写入文件系统，当queue中内容全部写完时将唤醒主线程。当子线程由于未捕获的异常挂掉的时候，主线程会由于无法被唤醒而卡死。
## Bug修复：
  目前子线程会由于未捕获的异常挂掉的情况发生在往BOS文件系统中写入内容时，并且报异常是由于token invalid。
  在VisualDL代码方面，加入了几个异常捕获。
  1. 在visualdl/io/bfile.py中，BosFileSystem.append函数负责往文件追加内容，其中有两个可能会引发异常的地方，加入了异常捕获，当token失效时候重新申请token，重新创建bos client。
  2. 在visualdl/writer/record_wrtier.py中，_AsyncWriterThread.run函数中加入了异常捕获，防止有其它未知的异常没有被捕获时，导致线程挂掉，从而使主线程卡死，并给出Warning,提醒用户此时数据已经写不进文件系统了。
 

