### PR TITLE
fix a bug when app.run with model is None

### DIFF
--- a/visualdl/server/api.py
+++ b/visualdl/server/api.py
@@ -65,7 +65,9 @@ class Api(object):
         self._reader = LogReader(logdir)
         if model:
             self._reader.model = model
-        self.model_name = os.path.basename(model)
+            self.model_name = os.path.basename(model)
+        else:
+            self.model_name = ''
 
         # use a memory cache to reduce disk reading frequency.
         cache = MemCache(timeout=cache_timeout)


### PR DESCRIPTION
## Bug描述：
当app.run放入model=None时，会报错。
![3ad6da5a0fb8d4a8f41b6b7b18aba862](https://user-images.githubusercontent.com/22424850/136751589-b8708809-578c-44c0-936b-79a4a7ab598a.png)
## Bug原因：
在api.py中，没有判断model的值直接对其使用了os.path.basename，导致报错。
## Bug修复：
判断是否为None, 如果是None的话则默认设置为空串。
