### PR TITLE
易用性bug修复

### DIFF
--- a/frontend/packages/core/src/components/GraphPage/Argument.tsx
+++ b/frontend/packages/core/src/components/GraphPage/Argument.tsx
@@ -96,7 +96,7 @@ const Argument: FunctionComponent<ArgumentProps> = ({value, expand, showNodeDocu
                             {value.name}: <b>{value.value}</b>
                         </>
                     ) : (
-                        value.value.split('\n').map((line, index) => (
+                        new String(value.value).split('\n').map((line, index) => (
                             <React.Fragment key={index}>
                                 {index !== 0 && <br />}
                                 {line}

--- a/frontend/packages/core/src/components/LineChart.tsx
+++ b/frontend/packages/core/src/components/LineChart.tsx
@@ -14,150 +14,183 @@
  * limitations under the License.
  */
 
-import * as chart from '~/utils/chart';
+ import * as chart from '~/utils/chart';
 
-import React, {useEffect, useImperativeHandle} from 'react';
-import {WithStyled, primaryColor} from '~/utils/style';
-import useECharts, {Options, Wrapper, useChartTheme} from '~/hooks/useECharts';
-
-import type {EChartOption} from 'echarts';
-import GridLoader from 'react-spinners/GridLoader';
-import defaultsDeep from 'lodash/defaultsDeep';
-import {formatTime} from '~/utils';
-import {useTranslation} from 'react-i18next';
-
-type LineChartProps = {
-    options?: EChartOption;
-    title?: string;
-    data?: Partial<NonNullable<EChartOption<EChartOption.SeriesLine>['series']>>;
-    loading?: boolean;
-    zoom?: boolean;
-    onInit?: Options['onInit'];
-};
-
-export enum XAxisType {
-    value = 'value',
-    log = 'log',
-    time = 'time'
-}
-
-export enum YAxisType {
-    value = 'value',
-    log = 'log'
-}
-
-export type LineChartRef = {
-    restore(): void;
-    saveAsImage(): void;
-};
-
-const LineChart = React.forwardRef<LineChartRef, LineChartProps & WithStyled>(
-    ({options, data, title, loading, zoom, className, onInit}, ref) => {
-        const {i18n} = useTranslation();
-
-        const {
-            ref: echartRef,
-            echart,
-            wrapper,
-            saveAsImage
-        } = useECharts<HTMLDivElement>({
-            loading: !!loading,
-            zoom,
-            autoFit: true,
-            onInit
-        });
-
-        const theme = useChartTheme();
-
-        useImperativeHandle(ref, () => ({
-            restore: () => {
-                echart?.dispatchAction({
-                    type: 'restore'
-                });
-            },
-            saveAsImage: () => {
-                saveAsImage(title);
-            }
-        }));
-
-        useEffect(() => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const {color, colorAlt, series, ...defaults} = chart;
-
-            let chartOptions: EChartOption = defaultsDeep(
-                {
-                    title: {
-                        text: title ?? ''
-                    },
-                    xAxis: {
-                        splitLine: {
-                            show: false
-                        },
-                        splitNumber: 5
-                    },
-                    yAxis: {
-                        splitNumber: 4
-                    },
-                    series: data?.map((item, index) =>
-                        defaultsDeep(
-                            {
-                                // show symbol if there is only one point
-                                showSymbol: (item?.data?.length ?? 0) <= 1,
-                                type: 'line'
-                            },
-                            item,
-                            {
-                                lineStyle: {
-                                    color: color[index % color.length],
-                                    width: 1.5
-                                }
-                            },
-                            series
-                        )
-                    )
-                },
-                options,
-                theme,
-                defaults
-            );
-            if ((chartOptions?.xAxis as EChartOption.XAxis).type === 'time') {
-                chartOptions = defaultsDeep(
-                    {
-                        xAxis: {
-                            axisLabel: {
-                                formatter: (value: number) => formatTime(value, i18n.language, 'LTS')
-                            }
-                        }
-                    },
-                    chartOptions
-                );
-            }
-            if ((chartOptions?.yAxis as EChartOption.YAxis).type === 'time') {
-                chartOptions = defaultsDeep(
-                    {
-                        yAxis: {
-                            axisLabel: {
-                                formatter: (value: number) => formatTime(value, i18n.language, 'LTS')
-                            }
-                        }
-                    },
-                    chartOptions
-                );
-            }
-            echart?.setOption(chartOptions, {notMerge: true});
-        }, [options, data, title, theme, i18n.language, echart]);
-
-        return (
-            <Wrapper ref={wrapper} className={className}>
-                {!echart && (
-                    <div className="loading">
-                        <GridLoader color={primaryColor} size="10px" />
-                    </div>
-                )}
-                <div className="echarts" ref={echartRef}></div>
-            </Wrapper>
-        );
-    }
-);
-
-export default LineChart;
+ import React, {useEffect, useImperativeHandle,useState} from 'react';
+ import {WithStyled, primaryColor} from '~/utils/style';
+ import useECharts, {Options, Wrapper, useChartTheme} from '~/hooks/useECharts';
+ 
+ import type {EChartOption} from 'echarts';
+ import GridLoader from 'react-spinners/GridLoader';
+ import defaultsDeep from 'lodash/defaultsDeep';
+ import {formatTime} from '~/utils';
+ import debounce from 'lodash/debounce';
+ import {useTranslation} from 'react-i18next';
+ 
+ type LineChartProps = {
+     options?: EChartOption;
+     title?: string;
+     data?: Partial<NonNullable<EChartOption<EChartOption.SeriesLine>['series']>>;
+     loading?: boolean;
+     zoom?: boolean;
+     onInit?: Options['onInit'];
+ };
+ 
+ export enum XAxisType {
+     value = 'value',
+     log = 'log',
+     time = 'time'
+ }
+ 
+ export enum YAxisType {
+     value = 'value',
+     log = 'log'
+ }
+ 
+ export type LineChartRef = {
+     restore(): void;
+     saveAsImage(): void;
+ };
+ export type DataZooms = {
+     type?:string
+     start?: number;
+     end?: number;
+     startValue?: number;
+     endValue?: number;
+     dataZoomIndex:string
+ };
+ const LineChart = React.forwardRef<LineChartRef, LineChartProps & WithStyled>(
+     ({options, data, title, loading, zoom, className, onInit}, ref) => {
+         const {i18n} = useTranslation();
+         const [dataZooms,setdataZooms] =useState<DataZooms[]>([])
+         const {
+             ref: echartRef,
+             echart,
+             wrapper,
+             saveAsImage
+         } = useECharts<HTMLDivElement>({
+             loading: !!loading,
+             zoom,
+             autoFit: true,
+             onInit
+         });
+ 
+         const theme = useChartTheme();
+ 
+         useImperativeHandle(ref, () => ({
+             restore: () => {
+                 // echart?.dispatchAction({
+                 //     type: 'restore'
+                 // });
+                 const { dispatchAction } = echart?._api;
+                 dispatchAction({
+                     type: 'dataZoom',
+                     start: 0,
+                     end: 100,
+                   })
+             },
+             saveAsImage: () => {
+                 saveAsImage(title);
+             }
+         }));
+ 
+         useEffect(() => {
+             // eslint-disable-next-line @typescript-eslint/no-unused-vars
+             const {color, colorAlt, series, ...defaults} = chart;
+ 
+             let chartOptions: EChartOption = defaultsDeep(
+                 {
+                     title: {
+                         text: title ?? ''
+                     },
+                     xAxis: {
+                         splitLine: {
+                             show: false
+                         },
+                         splitNumber: 5
+                     },
+                     yAxis: {
+                         splitNumber: 4
+                     },
+                     series: data?.map((item, index) =>
+                         defaultsDeep(
+                             {
+                                 // show symbol if there is only one point
+                                 showSymbol: (item?.data?.length ?? 0) <= 1,
+                                 type: 'line'
+                             },
+                             item,
+                             {
+                                 lineStyle: {
+                                     color: color[index % color.length],
+                                     width: 1.5
+                                 }
+                             },
+                             series
+                         )
+                     )
+                 },
+                 options,
+                 theme,
+                 defaults
+             );
+             if((dataZooms as DataZooms[]).length){
+                 console.log('dataZooms.start',dataZooms);
+                 chartOptions = defaultsDeep(
+                     {
+                         dataZoom:[...(dataZooms as DataZooms[])]
+                     },
+                     chartOptions
+                 );
+             }
+             if ((chartOptions?.xAxis as EChartOption.XAxis).type === 'time') {
+                 chartOptions = defaultsDeep(
+                     {
+                         xAxis: {
+                             axisLabel: {
+                                 formatter: (value: number) => formatTime(value, i18n.language, 'LTS')
+                             }
+                         }
+                     },
+                     chartOptions
+                 );
+             }
+             if ((chartOptions?.yAxis as EChartOption.YAxis).type === 'time') {
+                 chartOptions = defaultsDeep(
+                     {
+                         yAxis: {
+                             axisLabel: {
+                                 formatter: (value: number) => formatTime(value, i18n.language, 'LTS')
+                             }
+                         }
+                     },
+                     chartOptions
+                 );
+             }
+             echart?.setOption(chartOptions, {notMerge: true});
+         }, [options, data, title, theme, i18n.language, echart]);
+         const onDataZoom = debounce((params: any) => {
+             let dataZoom = echart?._api.getModel().option.dataZoom.map((item:any,index:number)=>{
+                 delete item.id
+                 return item
+         })
+             setdataZooms(dataZoom)
+             console.log('echart option',echart?._api.getModel().option.dataZoom);
+         },500)
+         
+         echart?.on('datazoom', onDataZoom)
+         return (
+             <Wrapper ref={wrapper} className={className}>
+                 {!echart && (
+                     <div className="loading">
+                         <GridLoader color={primaryColor} size="10px" />
+                     </div>
+                 )}
+                 <div className="echarts" ref={echartRef}></div>
+             </Wrapper>
+         );
+     }
+ );
+ 
+ export default LineChart;
+ 


### PR DESCRIPTION
易用性bug修复
bug1 网络结构，点击结构图报错
出现场景：上传特定模型文件，生成对应网络结构，点击结构图页面报错
bug2 ：数据刷新后，图表的缩放回归初始位置
出现场景：数据刷新，或者数据筛选项，页面缩放回归初始位置