### PR TITLE
[Fix] do not crash vdl when logdir is missing

### DIFF
--- a/visualdl/component/profiler/profiler_reader.py
+++ b/visualdl/component/profiler/profiler_reader.py
@@ -66,8 +66,9 @@ class ProfilerReader(object):
         self.run_managers = {}
         self.profile_result_queue = Queue()
         self.tempfile = None
-        self.runs()
-        Thread(target=self._get_data_from_queue, args=()).start()
+        if logdir:
+            self.runs()
+            Thread(target=self._get_data_from_queue, args=()).start()
 
     @property
     def logdir(self):


### PR DESCRIPTION
当用户没有指定logdir参数时，尽管后台会报错误，但是可能为了让静态图页面能正常使用，之前的实现并没有选择退出程序，加入Profiler功能的时候，如果没有指定logdir参数会触发错误而退出程序，该pr修复了这一问题。