### PR TITLE
fix graph

### DIFF
--- a/visualdl/component/graph/graph_component.py
+++ b/visualdl/component/graph/graph_component.py
@@ -111,7 +111,7 @@ def construct_edges(var_name, all_ops, all_vars, all_edges):
             src_base_node = src_node
             while True:
                 parent_node = all_ops[src_base_node]['parent_node']
-                if parent_node == common_ancestor:
+                if parent_node in [common_ancestor, ""]:
                     break
                 if (src_base_node, parent_node) not in all_edges:
                     all_edges[(src_base_node, parent_node)] = {
@@ -127,7 +127,7 @@ def construct_edges(var_name, all_ops, all_vars, all_edges):
             dst_base_node = dst_node
             while True:
                 parent_node = all_ops[dst_base_node]['parent_node']
-                if parent_node == common_ancestor:
+                if parent_node in [common_ancestor, ""]:
                     break
                 if (parent_node, dst_base_node) not in all_edges:
                     all_edges[(parent_node, dst_base_node)] = {


### PR DESCRIPTION
在复现yolov5 releasev7.0的过程中，实现visualDL的add_graph出现`KeyError: ''`，发现在`graph_component.py`的`construct_edges`函数中，出现`src_base_node=''`和`dst_base_node=''`的情况，当父节点`parent_node`来到`common_ancestor`或者空节点时，都应该退出循环
```
if parent_node == common_ancestor: → if parent_node in [common_ancestor, ""]:
```

visualDL==2.5.1

