### PR TITLE
[Bug] Fix export graph bug in windows

### DIFF
--- a/visualdl/component/graph/graph_component.py
+++ b/visualdl/component/graph/graph_component.py
@@ -14,6 +14,7 @@
 # =======================================================================
 import collections
 import os.path
+import pathlib
 import re
 
 _graph_version = '1.0.0'
@@ -108,6 +109,7 @@ def construct_edges(var_name, all_ops, all_vars, all_edges):
                 all_edges[(src_node, dst_node)]['vars'].add(var_name)
         else:
             common_ancestor = os.path.commonpath([src_node, dst_node])
+            common_ancestor = pathlib.Path(common_ancestor).as_posix()  # in windows, os.path.commonpath will return windows path, we should convert it to posix
             src_base_node = src_node
             while True:
                 parent_node = all_ops[src_base_node]['parent_node']

--- a/visualdl/component/graph/graph_component.py
+++ b/visualdl/component/graph/graph_component.py
@@ -109,7 +109,8 @@ def construct_edges(var_name, all_ops, all_vars, all_edges):
                 all_edges[(src_node, dst_node)]['vars'].add(var_name)
         else:
             common_ancestor = os.path.commonpath([src_node, dst_node])
-            common_ancestor = pathlib.Path(common_ancestor).as_posix()  # in windows, os.path.commonpath will return windows path, we should convert it to posix
+            common_ancestor = pathlib.Path(common_ancestor).as_posix(
+            )  # in windows, os.path.commonpath will return windows path, we should convert it to posix
             src_base_node = src_node
             while True:
                 parent_node = all_ops[src_base_node]['parent_node']


### PR DESCRIPTION
1. Fix export graph bug in windows.
    由于考虑节点层次路径的时候，设计的时候使用的是posix的路径表示，通过/来分隔路径层次，使用os.path.commonpath在windows下返回的会是windows下的路径表示，用\来分割，导致windows下功能失效。现在修复了这一问题