### PR TITLE
Fix compatible problem for python3.10 and gradio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,7 @@ packaging
 x2paddle >= 1.4.0
 paddle2onnx >= 1.0.5
 rarfile
-gradio
+gradio == 3.11.0
 tritonclient[all]
-attrdict
 psutil
 onnx >= 1.6.0

--- a/visualdl/component/inference/fastdeploy_client/http_client_manager.py
+++ b/visualdl/component/inference/fastdeploy_client/http_client_manager.py
@@ -18,13 +18,6 @@ import re
 import numpy as np
 import requests
 import tritonclient.http as httpclient
-from attrdict import AttrDict
-
-
-def convert_http_metadata_config(metadata):
-    metadata = AttrDict(metadata)
-
-    return metadata
 
 
 def prepare_request(inputs_meta, inputs_data, outputs_meta):
@@ -58,7 +51,7 @@ def prepare_request(inputs_meta, inputs_data, outputs_meta):
         inputs.append(infer_input)
     outputs = []
     for output_dict in outputs_meta:
-        infer_output = httpclient.InferRequestedOutput(output_dict.name)
+        infer_output = httpclient.InferRequestedOutput(output_dict['name'])
         outputs.append(infer_output)
     return inputs, outputs
 
@@ -321,8 +314,8 @@ class HttpClientManager:
 
         results = {}
         for output in output_metadata:
-            result = response.as_numpy(output.name)  # datatype: numpy
-            if output.datatype == 'BYTES':  # datatype: bytes
+            result = response.as_numpy(output['name'])  # datatype: numpy
+            if output['datatype'] == 'BYTES':  # datatype: bytes
                 try:
                     value = result
                     if len(result.shape) == 1:
@@ -336,7 +329,7 @@ class HttpClientManager:
                     pass
             else:
                 result = result[0]
-            results[output.name] = result
+            results[output['name']] = result
         return results
 
     def raw_infer(self, server_url, model_name, model_version, raw_input):
@@ -353,8 +346,6 @@ class HttpClientManager:
         except Exception as e:
             raise RuntimeError("Failed to retrieve the metadata: " + str(e))
 
-        model_metadata = convert_http_metadata_config(model_metadata)
-
-        input_metadata = model_metadata.inputs
-        output_metadata = model_metadata.outputs
+        input_metadata = model_metadata['inputs']
+        output_metadata = model_metadata['outputs']
         return input_metadata, output_metadata


### PR DESCRIPTION
1. 修复一下fastdeploy client在高版本gradio下的显示问题。
2. 由于attrdict在python3.10会报错，移除对attrdict的使用