### PR TITLE
[Bug] fix _build_tree_relationship in ProfilerResult

### DIFF
--- a/visualdl/component/profiler/parser/event_node.py
+++ b/visualdl/component/profiler/parser/event_node.py
@@ -484,7 +484,24 @@ class ProfilerResult:
                             if not hasenter:
                                 firstposition = i
                                 hasenter = True
-                            stack_top_node.runtime_node.append(runtimenode)
+                            inserted_node = stack_top_node
+                            runtimenode_stack = [stack_top_node]
+                            while runtimenode_stack:
+                                inserted_node = runtimenode_stack.pop()
+                                if inserted_node is not None:
+                                    runtimenode_stack.append(inserted_node)
+                                    runtimenode_stack.append(None)
+                                    for child in reversed(inserted_node.runtime_node):
+                                        if runtimenode.start_ns >= child.start_ns and \
+                                            runtimenode.end_ns <= child.end_ns:
+                                            runtimenode_stack.append(child)
+                                else:
+                                    inserted_node = runtimenode_stack.pop()
+                                    if runtimenode.start_ns >= inserted_node.start_ns and \
+                                            runtimenode.end_ns <= inserted_node.end_ns:
+                                        inserted_node.runtime_node.append(runtimenode)
+                                        break
+
                         else:
                             # from this runtime node, not within stack_top_node, erase the
                             # nodes from runtime_event_nodes
@@ -506,7 +523,23 @@ class ProfilerResult:
                     if not hasenter:
                         firstposition = i
                         hasenter = True
-                    stack_top_node.runtime_node.append(runtimenode)
+                    inserted_node = stack_top_node
+                    runtimenode_stack = [stack_top_node]
+                    while runtimenode_stack:
+                        inserted_node = runtimenode_stack.pop()
+                        if inserted_node is not None:
+                            runtimenode_stack.append(inserted_node)
+                            runtimenode_stack.append(None)
+                            for child in reversed(inserted_node.runtime_node):
+                                if runtimenode.start_ns >= child.start_ns and \
+                                    runtimenode.end_ns <= child.end_ns:
+                                    runtimenode_stack.append(child)
+                        else:
+                            inserted_node = runtimenode_stack.pop()
+                            if runtimenode.start_ns >= inserted_node.start_ns and \
+                                    runtimenode.end_ns <= inserted_node.end_ns:
+                                inserted_node.runtime_node.append(runtimenode)
+                                break
                 else:
                     # from this runtime node, not within stack_top_node, erase the
                     # nodes from runtime_event_nodes


### PR DESCRIPTION
### bug描述：
当OP调用runtimeP，而runtime P调用runtime C时，两个runtime会成为兄弟节点 存放在 `OP.runtime_node` 中

### 期望：
runtime C应该成为runtime P的子runtime节点
```
OP
  .runtime_node=[
    runtime P
      .runtime_node=[
          runtime C
      ]
  ]
```
### 附件
附件中是一个脱敏的样例，`cudaRT_P` 调用了 `cudaRT_C`

