### PR TITLE
Fix deprecated np.float usage for NumPy 1.20+ compatibility

### DIFF
--- a/visualdl/component/base_component.py
+++ b/visualdl/component/base_component.py
@@ -383,7 +383,7 @@ def compute_curve(labels, predictions, num_thresholds=None, weights=None):
         weights = 1.0
 
     bucket_indices = np.int32(np.floor(predictions * (num_thresholds - 1)))
-    float_labels = labels.astype(np.float)
+    float_labels = labels.astype(np.float32)
     histogram_range = (0, num_thresholds - 1)
     tp_buckets, _ = np.histogram(
         bucket_indices,
@@ -512,7 +512,7 @@ def compute_roc_curve(labels, predictions, num_thresholds=None, weights=None):
         weights = 1.0
 
     bucket_indices = np.int32(np.floor(predictions * (num_thresholds - 1)))
-    float_labels = labels.astype(np.float)
+    float_labels = labels.astype(np.float32)
     histogram_range = (0, num_thresholds - 1)
     tp_buckets, _ = np.histogram(
         bucket_indices,


### PR DESCRIPTION
### Description
This PR fixes the deprecation warning/error caused by using `np.float` in NumPy 1.20+.

### Problem
In NumPy 1.20+, `np.float` is deprecated and will raise an AttributeError:

```Bash
AttributeError: module 'numpy' has no attribute 'float'.
np.float was a deprecated alias for the builtin float.
Use float or np.float64 instead.
```
This affects users with newer NumPy versions when using PR/ROC curve logging.

### Changes
- Replace `np.float` with `np.float32` in `base_component.py` (lines 386 and 515)
- This ensures compatibility with NumPy 1.20+ while maintaining the same behavior

### Testing
Tested with:
- NumPy 1.24.0 ✅
- PR/ROC curve functionality remains unchanged

